### PR TITLE
Multiple set support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
+Note: For google and spotify auth to work you'll need to create an app for both of those to use.
+
 ## Features
 
 ### PDF Export Functionality
@@ -103,7 +105,7 @@ For spotify sign in to work locally add this to .env NEXTAUTH_URL="http://127.0.
 - User should have the ability to remove a band. ✅ **COMPLETED**
 - Display how many users a band has and show a list somewhere ✅ **COMPLETED**
 - Fix share band ✅ **COMPLETED**
-- Add testing
+- Add testing ** In Progress **
 - Multiple Set Support
 - Filter out songs based on tags 
 - Add (Album Version) to edge cases of spotify perfect match

--- a/app/bands/[id]/setlist/[setId]/page.tsx
+++ b/app/bands/[id]/setlist/[setId]/page.tsx
@@ -40,9 +40,14 @@ const SetlistPage = async (context: PageProps) => {
             id: Number(setId),
         },
         include: {
-            songs: {
-                include: { song: true },
-                orderBy: { order: 'asc' }
+            sets: {
+                orderBy: { order: 'asc' },
+                include: {
+                    setSongs: {
+                        orderBy: { order: 'asc' },
+                        include: { song: true },
+                    },
+                },
             },
             band: true
         }
@@ -69,7 +74,7 @@ const SetlistPage = async (context: PageProps) => {
         where: {
             bandId: Number(bandId),
             id: {
-                notIn: setList.songs.map(s => s.songId)
+                notIn: setList.sets.flatMap(set => set.setSongs.map(s => s.songId))
             }
         }
     })
@@ -99,9 +104,9 @@ const SetlistPage = async (context: PageProps) => {
                     </div>
                 </div>
                 <div className="mt-4 flex md:mt-0 md:ml-4">
-                    <ExportPDFButton setList={{...setList, songs: setList.songs.map(s => s.song), band: setList.band}} />
+                    <ExportPDFButton setList={{...setList, songs: setList.sets.flatMap(set => set.setSongs.map(s => s.song)), band: setList.band}} />
                     <div className="ml-3">
-                        <CreateSpotifyPlaylistModalButton setListId={setId} hasSpotify={hasSpotify} songs={setList.songs.map(s => s.song)} />
+                        <CreateSpotifyPlaylistModalButton setListId={String(setId)} hasSpotify={hasSpotify} songs={setList.sets.flatMap(set => set.setSongs.map(s => s.song))} />
                     </div>
                     <Link
                         href={`/bands/${bandId}/setlists`}
@@ -121,7 +126,7 @@ const SetlistPage = async (context: PageProps) => {
                         <h3 className="text-lg leading-6 font-medium text-gray-900">Repertoire</h3>
                     </div>
                     <div className="border-t border-gray-200">
-                        <SongList songList={songs} add={true} setList={setList}/>
+                        <SongList songList={songs} add={true} />
                     </div>
                 </div>
 
@@ -130,7 +135,20 @@ const SetlistPage = async (context: PageProps) => {
                         <h3 className="text-lg leading-6 font-medium text-gray-900">Set List</h3>
                     </div>
                     <div className="border-t border-gray-200">
-                        <SongList songList={setList.songs} add={false} setList={setList}/>
+                        {setList.sets.map(set => (
+                            <div key={set.id} className="mb-8">
+                                <h4 className="text-md font-semibold text-gray-700 mb-4 mt-6 ml-4">{set.name}</h4>
+                                <SongList songList={set.setSongs.map(s => ({
+                                    id: s.id,
+                                    setListId: setList.id,
+                                    songId: s.songId,
+                                    order: s.order,
+                                    createdAt: s.createdAt,
+                                    updatedAt: s.updatedAt,
+                                    song: s.song
+                                }))} add={false} setId={set.id} />
+                            </div>
+                        ))}
                     </div>
                 </div>
             </div>

--- a/app/bands/[id]/setlist/[setId]/page.tsx
+++ b/app/bands/[id]/setlist/[setId]/page.tsx
@@ -1,14 +1,16 @@
 import SongList from "@/components/SongList";
 import prisma from "@/utils/db";
-import { PageProps } from "@/.next/types/app/page";
+import { GetServerSidePropsContext } from "next";
 import Link from "next/link";
 import { editSetList, createSpotifyPlaylistFromSetlist } from "@/utils/serverActions";
 import { Song } from "@prisma/client";
 import CreateSpotifyPlaylistModalButton from '@/components/CreateSpotifyPlaylistModalButton';
 import ExportPDFButton from '@/components/ExportPDFButton';
 import getUser from "@/utils/getUser";
+import AddSongToSetDropdown from "@/components/AddSongToSetDropdown";
+import { useState } from "react";
 
-const SetlistPage = async (context: PageProps) => {
+const SetlistPage = async (context: any) => {
     const bandId = context.params.id;
     const setId = context.params.setId;
 
@@ -137,7 +139,11 @@ const SetlistPage = async (context: PageProps) => {
                     <div className="border-t border-gray-200">
                         {setList.sets.map(set => (
                             <div key={set.id} className="mb-8">
-                                <h4 className="text-md font-semibold text-gray-700 mb-4 mt-6 ml-4">{set.name}</h4>
+                                <div className="flex items-center">
+                                  <h4 className="text-md font-semibold text-gray-700 mb-4 mt-6 ml-4">{set.name}</h4>
+                                  {/* Add button for adding repertoire songs to this set */}
+                                  <AddSongToSetDropdown setId={set.id} repertoire={songs} />
+                                </div>
                                 <SongList songList={set.setSongs.map(s => ({
                                     id: s.id,
                                     setListId: setList.id,

--- a/app/bands/[id]/setlist/[setId]/page.tsx
+++ b/app/bands/[id]/setlist/[setId]/page.tsx
@@ -1,14 +1,13 @@
 import SongList from "@/components/SongList";
 import prisma from "@/utils/db";
-import { GetServerSidePropsContext } from "next";
 import Link from "next/link";
-import { editSetList, createSpotifyPlaylistFromSetlist } from "@/utils/serverActions";
+import { editSetList } from "@/utils/serverActions";
 import { Song } from "@prisma/client";
 import CreateSpotifyPlaylistModalButton from '@/components/CreateSpotifyPlaylistModalButton';
 import ExportPDFButton from '@/components/ExportPDFButton';
 import getUser from "@/utils/getUser";
 import AddSongToSetDropdown from "@/components/AddSongToSetDropdown";
-import { useState } from "react";
+
 
 const SetlistPage = async (context: any) => {
     const bandId = context.params.id;
@@ -85,8 +84,8 @@ const SetlistPage = async (context: any) => {
     const accessToken = session?.accessToken;
     const hasSpotify = !!accessToken;
 
-    const updateSetList = async (song: Song, add: boolean) => {
-        return editSetList(setList, song, add)
+    const updateSetList = async (song: Song, add: boolean, setIdOverride?: number) => {
+        return editSetList(setIdOverride ?? setId, song, add)
     }
 
     return (

--- a/components/AddSongToSetDropdown.tsx
+++ b/components/AddSongToSetDropdown.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import { Song } from '@prisma/client';
+import { editSetList } from '@/utils/serverActions';
+
+interface AddSongToSetDropdownProps {
+  setId: number;
+  repertoire: Song[];
+}
+
+const AddSongToSetDropdown = ({ setId, repertoire }: AddSongToSetDropdownProps) => {
+  const [selectedSongId, setSelectedSongId] = useState<number | undefined>();
+  const [isPending, setIsPending] = useState(false);
+
+  const handleAdd = async () => {
+    if (!selectedSongId) return;
+    setIsPending(true);
+    const song = repertoire.find(s => s.id === selectedSongId);
+    if (song) {
+      await editSetList(setId, song, true);
+      setSelectedSongId(undefined);
+    }
+    setIsPending(false);
+  };
+
+  if (repertoire.length === 0) return null;
+
+  return (
+    <div className="flex items-center space-x-2 ml-4">
+      <select
+        className="border rounded px-2 py-1 text-sm"
+        value={selectedSongId ?? ''}
+        onChange={e => setSelectedSongId(Number(e.target.value))}
+        disabled={isPending}
+      >
+        <option value="" disabled>Select song to add</option>
+        {repertoire.map(song => (
+          <option key={song.id} value={song.id}>{song.title}{song.artist ? ` – ${song.artist}` : ''}</option>
+        ))}
+      </select>
+      <button
+        className="px-2 py-1 bg-green-600 text-white rounded text-sm disabled:opacity-50"
+        onClick={handleAdd}
+        disabled={!selectedSongId || isPending}
+      >
+        Add
+      </button>
+    </div>
+  );
+};
+
+export default AddSongToSetDropdown; 

--- a/components/EditSetListButton.tsx
+++ b/components/EditSetListButton.tsx
@@ -6,13 +6,13 @@ import { editSetList } from "@/utils/serverActions"
 interface EditSetListButtonProps {
     song: Song;
     add: boolean;
-    setList: SetList;
+    setId: number;
 }
 
-const EditSetListButton = ({ song, add, setList }: EditSetListButtonProps) => {
+const EditSetListButton = ({ song, add, setId }: EditSetListButtonProps) => {
     return (
         <button
-            onClick={() => editSetList(setList, song, add)}
+            onClick={() => editSetList(setId, song, add)}
             className={`inline-flex items-center px-3 py-1.5 border text-sm font-medium rounded-md transition-colors duration-200 ${
                 add 
                     ? 'border-green-300 text-green-700 bg-green-50 hover:bg-green-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500' 

--- a/components/SongList.tsx
+++ b/components/SongList.tsx
@@ -22,10 +22,10 @@ export type SetListSongWithSong = {
 export type SongListProps = {
     songList: Song[] | SetListSongWithSong[],
     add?: boolean,
-    setList?: SetList
+    setId?: number
 }
 
-const SongList = ({songList, add, setList}: SongListProps) => {
+const SongList = ({songList, add, setId}: SongListProps) => {
     const [isPending, startTransition] = useTransition();
     
     // Convert Song[] to SetListSongWithSong[] format if needed
@@ -40,14 +40,14 @@ const SongList = ({songList, add, setList}: SongListProps) => {
         // Convert Song[] to SetListSongWithSong[] format
         return (songList as Song[]).map((song, index) => ({
             id: song.id, // Use song.id as the join ID for repertoire
-            setListId: setList?.id || 0,
+            setListId: setId || 0,
             songId: song.id,
             order: index + 1,
             createdAt: song.createdAt,
             updatedAt: song.updatedAt,
             song: song
         }));
-    }, [songList, setList]);
+    }, [songList, setId]);
 
     const [localSongs, setLocalSongs] = React.useState(normalizedSongs);
 
@@ -61,10 +61,10 @@ const SongList = ({songList, add, setList}: SongListProps) => {
         const [removed] = reordered.splice(result.source.index, 1);
         reordered.splice(result.destination.index, 0, removed);
         setLocalSongs(reordered);
-        // Persist new order if setList is present and this is a setlist (not repertoire)
-        if (setList && !add) {
+        // Persist new order if setId is present and this is a set (not repertoire)
+        if (setId && !add) {
             startTransition(() => {
-                reorderSetListSongs(setList.id, reordered.map(s => s.id));
+                reorderSetListSongs(setId, reordered.map(s => s.id));
             });
         }
     };
@@ -92,7 +92,7 @@ const SongList = ({songList, add, setList}: SongListProps) => {
     }
 
     // Only enable drag-and-drop for set lists (not repertoire)
-    if (setList && !add) {
+    if (setId && !add) {
         return (
             <DragDropContext onDragEnd={onDragEnd}>
                 <Droppable droppableId="setlist-songs">
@@ -140,8 +140,7 @@ const SongList = ({songList, add, setList}: SongListProps) => {
                                                     <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                                                         <div className="flex items-center justify-end space-x-2">
                                                             <EditSongForm song={setListSong.song} />
-                                                            {!setList && <DeleteSongButton id={setListSong.song.id} />}
-                                                            {setList && <EditSetListButton song={setListSong.song} add={add || false} setList={setList} />}
+                                                            <EditSetListButton song={setListSong.song} add={add || false} setId={setId} />
                                                         </div>
                                                     </td>
                                                 </tr>
@@ -201,8 +200,8 @@ const SongList = ({songList, add, setList}: SongListProps) => {
                             <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                                 <div className="flex items-center justify-end space-x-2">
                                     <EditSongForm song={setListSong.song} />
-                                    {!setList && <DeleteSongButton id={setListSong.song.id} />}
-                                    {setList && <EditSetListButton song={setListSong.song} add={add || false} setList={setList} />}
+                                    {!setId && <DeleteSongButton id={setListSong.song.id} />}
+                                    {setId && <EditSetListButton song={setListSong.song} add={add || false} setId={setId} />}
                                 </div>
                             </td>
                         </tr>

--- a/prisma/migrations/20250704183854_add_sets_and_setsong/migration.sql
+++ b/prisma/migrations/20250704183854_add_sets_and_setsong/migration.sql
@@ -1,0 +1,57 @@
+-- CreateTable
+CREATE TABLE "Set" (
+    "id" SERIAL NOT NULL,
+    "setListId" INTEGER NOT NULL,
+    "name" VARCHAR(255) NOT NULL,
+    "order" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Set_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SetSong" (
+    "id" SERIAL NOT NULL,
+    "setId" INTEGER NOT NULL,
+    "songId" INTEGER NOT NULL,
+    "order" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SetSong_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Set_setListId_order_key" ON "Set"("setListId", "order");
+
+-- CreateIndex
+CREATE INDEX "SetSong_songId_idx" ON "SetSong"("songId");
+
+-- CreateIndex
+CREATE INDEX "SetSong_setId_order_idx" ON "SetSong"("setId", "order");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SetSong_setId_songId_key" ON "SetSong"("setId", "songId");
+
+-- AddForeignKey
+ALTER TABLE "Set" ADD CONSTRAINT "Set_setListId_fkey" FOREIGN KEY ("setListId") REFERENCES "SetList"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SetSong" ADD CONSTRAINT "SetSong_setId_fkey" FOREIGN KEY ("setId") REFERENCES "Set"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SetSong" ADD CONSTRAINT "SetSong_songId_fkey" FOREIGN KEY ("songId") REFERENCES "Song"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- Data migration: Move existing SetListSong data into new Set/SetSong structure
+
+-- For each SetList, create a single Set (order=1, name='Set 1')
+INSERT INTO "Set" ("setListId", "name", "order", "createdAt", "updatedAt")
+SELECT DISTINCT "setListId", 'Set 1', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+FROM "SetListSong";
+
+-- For each SetListSong, create a SetSong in the corresponding Set
+INSERT INTO "SetSong" ("setId", "songId", "order", "createdAt", "updatedAt")
+SELECT s."id", sls."songId", sls."order", sls."createdAt", sls."updatedAt"
+FROM "SetListSong" sls
+JOIN "Set" s ON s."setListId" = sls."setListId" AND s."order" = 1;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model Song {
   setLists  SetListSong[]
   data      Json?
   spotifyPerfectMatch Boolean @default(false)
+  setSongs  SetSong[]
 }
 
 model SetList {
@@ -46,6 +47,7 @@ model SetList {
   songs     SetListSong[]
   band      Band     @relation(fields: [bandId], references: [id])
   bandId    Int
+  sets      Set[]
 }
 
 model User {
@@ -133,4 +135,33 @@ model SetListSong {
   @@unique([setListId, songId])
   @@index([songId])
   @@index([setListId, order])
+}
+
+model Set {
+  id        Int      @id @default(autoincrement())
+  setList   SetList  @relation(fields: [setListId], references: [id], onDelete: Cascade)
+  setListId Int
+  name      String   @db.VarChar(255)
+  order     Int      // The position of the set within the setlist
+  setSongs  SetSong[]
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([setListId, order])
+}
+
+model SetSong {
+  id      Int    @id @default(autoincrement())
+  set     Set    @relation(fields: [setId], references: [id], onDelete: Cascade)
+  setId   Int
+  song    Song   @relation(fields: [songId], references: [id], onDelete: Cascade)
+  songId  Int
+  order   Int    // The position of the song within the set
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([setId, songId])
+  @@index([songId])
+  @@index([setId, order])
 }

--- a/scripts/migrate_setlist_data.ts
+++ b/scripts/migrate_setlist_data.ts
@@ -1,0 +1,28 @@
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+async function migrateSetListData() {
+  // 1. Create a Set for each SetList
+  await prisma.$executeRawUnsafe(`
+    INSERT INTO "Set" ("setListId", "name", "order", "createdAt", "updatedAt")
+    SELECT DISTINCT "setListId", 'Set 1', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+    FROM "SetListSong";
+  `);
+
+  // 2. Move SetListSong entries to SetSong
+  await prisma.$executeRawUnsafe(`
+    INSERT INTO "SetSong" ("setId", "songId", "order", "createdAt", "updatedAt")
+    SELECT s."id", sls."songId", sls."order", sls."createdAt", sls."updatedAt"
+    FROM "SetListSong" sls
+    JOIN "Set" s ON s."setListId" = sls."setListId" AND s."order" = 1;
+  `);
+
+  console.log('Migration complete!');
+  await prisma.$disconnect();
+}
+
+migrateSetListData().catch(e => {
+  console.error(e);
+  process.exit(1);
+}); 

--- a/utils/pdfExport.ts
+++ b/utils/pdfExport.ts
@@ -2,7 +2,7 @@ import jsPDF from 'jspdf';
 import { SetListWithSongsAndBand, PDFExportOptions, PDFExportResult } from '@/types/pdf';
 
 export const exportSetListToPDF = (
-  setList: SetListWithSongsAndBand, 
+  setList: any, // Accepts sets for multi-set support
   options: PDFExportOptions = {}
 ): PDFExportResult => {
   try {
@@ -19,59 +19,73 @@ export const exportSetListToPDF = (
       unit: 'mm',
       format: pageSize
     });
-    
-    // Set up fonts and styling for stage visibility
     doc.setFont('helvetica');
-    
-    // Band name - large and prominent
+
+    // Helper to render a set (with optional heading)
+    const renderSet = (songs: any[], setHeading?: string, startY?: number) => {
+      let yPosition = startY ?? 60;
+      if (setHeading) {
+        doc.setFontSize(20);
+        doc.setFont('helvetica', 'bold');
+        doc.text(setHeading, doc.internal.pageSize.width / 2, yPosition - 10, { align: 'center' });
+        yPosition += 10;
+      }
+      songs.forEach((song, index) => {
+        if (yPosition > doc.internal.pageSize.height - 40) {
+          doc.addPage();
+          yPosition = setHeading ? 40 : 30;
+        }
+        const songNumber = index + 1;
+        doc.setFontSize(18);
+        doc.setFont('helvetica', 'bold');
+        doc.text(`${songNumber}.`, 20, yPosition);
+        doc.setFontSize(16);
+        doc.setFont('helvetica', 'normal');
+        let songText = song.title;
+        if (includeKey || includeArtist) {
+          const details = [];
+          if (includeKey && song.key) details.push(song.key);
+          if (includeArtist && song.artist) details.push(`Artist: ${song.artist}`);
+          if (details.length > 0) {
+            songText += ` (${details.join(' | ')})`;
+          }
+        }
+        doc.text(songText, 35, yPosition);
+        yPosition += 20;
+      });
+    };
+
+    // Band name - large and prominent (only on first page)
     doc.setFontSize(24);
     doc.setFont('helvetica', 'bold');
     doc.text(setList.band.name, doc.internal.pageSize.width / 2, 25, { align: 'center' });
-    
-    // Set list name
+    // Set list name (only on first page)
     doc.setFontSize(18);
     doc.text(setList.name, doc.internal.pageSize.width / 2, 40, { align: 'center' });
-    
-    // Songs list - start position
-    let yPosition = 60;
-    
-    setList.songs.forEach((song, index) => {
-      // Check if we need a new page
-      if (yPosition > doc.internal.pageSize.height - 40) {
-        doc.addPage();
-        yPosition = 30;
-      }
-      
-      const songNumber = index + 1;
-      
-      // Song number - large and bold
-      doc.setFontSize(18);
-      doc.setFont('helvetica', 'bold');
-      doc.text(`${songNumber}.`, 20, yPosition);
-      
-      // Song title and details on same line
-      doc.setFontSize(16);
-      doc.setFont('helvetica', 'normal');
-      
-      let songText = song.title;
-      
-      // Add key and artist info on same line if available
-      if (includeKey || includeArtist) {
-        const details = [];
-        if (includeKey && song.key) details.push(song.key);
-        if (includeArtist && song.artist) details.push(`Artist: ${song.artist}`);
-        
-        if (details.length > 0) {
-          songText += ` (${details.join(' | ')})`;
+
+    // Multi-set support
+    if (setList.sets && setList.sets.length > 1) {
+      setList.sets.forEach((set: any, idx: number) => {
+        if (idx > 0) doc.addPage();
+        // On first page, headings already rendered
+        if (idx === 0) {
+          renderSet(set.setSongs.map((s: any) => s.song), set.name || `Set ${idx + 1}`);
+        } else {
+          // On subsequent pages, set heading at top
+          let yPosition = 20;
+          doc.setFontSize(20);
+          doc.setFont('helvetica', 'bold');
+          doc.text(set.name || `Set ${idx + 1}`, doc.internal.pageSize.width / 2, yPosition, { align: 'center' });
+          renderSet(set.setSongs.map((s: any) => s.song), undefined, yPosition + 15);
         }
-      }
-      
-      doc.text(songText, 35, yPosition);
-      
-      // Move to next song position
-      yPosition += 20;
-    });
-    
+      });
+    } else if (setList.sets && setList.sets.length === 1) {
+      renderSet(setList.sets[0].setSongs.map((s: any) => s.song));
+    } else {
+      // Fallback: flat songs array (legacy)
+      renderSet(setList.songs);
+    }
+
     // Footer - simple page numbering
     const totalPages = doc.getNumberOfPages();
     for (let i = 1; i <= totalPages; i++) {
@@ -81,13 +95,10 @@ export const exportSetListToPDF = (
       doc.setTextColor(100, 100, 100);
       doc.text(`Page ${i} of ${totalPages}`, doc.internal.pageSize.width / 2, doc.internal.pageSize.height - 15, { align: 'center' });
     }
-    
+
     // Generate filename
     const filename = `${setList.band.name.replace(/[^a-zA-Z0-9]/g, '_')}_${setList.name.replace(/[^a-zA-Z0-9]/g, '_')}_setlist.pdf`;
-    
-    // Save the PDF
     doc.save(filename);
-    
     return {
       filename,
       success: true

--- a/utils/serverActions.ts
+++ b/utils/serverActions.ts
@@ -181,6 +181,16 @@ export const editSetList = async (
   });
   const setListId = set?.setListId;
 
+  // Fetch the bandId for the setList
+  let bandId: number | undefined = undefined;
+  if (setListId) {
+    const setList = await prisma.setList.findUnique({
+      where: { id: setListId },
+      select: { bandId: true }
+    });
+    bandId = setList?.bandId;
+  }
+
   if (add) {
     // Find the current max order for this set
     const maxOrder = await prisma.setSong.aggregate({
@@ -205,8 +215,8 @@ export const editSetList = async (
   }
 
   // Revalidate the setlist page
-  if (setListId) {
-    return revalidatePath(`/bands/set/${setListId}`);
+  if (setListId && bandId) {
+    return revalidatePath(`/bands/${bandId}/setlist/${setListId}`);
   }
   return revalidatePath('/');
 };


### PR DESCRIPTION
This pull request adds support for multiple sets in setlist creation. 

- Data structure changed, setlists now have an array of sets and songs are related to sets not setlists
- migration from previous data structure handled
- Ui updated to display multiple sets and allow multiple sets at set creation
- pdf export updated to properly handle multiple sets