### PR TITLE
12 add time location and details to setlist type

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For spotify sign in to work locally add this to .env NEXTAUTH_URL="http://127.0.
 - Allow reordering setlists with drag and drop. ✅ **COMPLETED**
 - Create printable setlists. ✅ **COMPLETED**
 - Method to send email or google calendar event to bandmates with setlist, playlist and event details. (ticket created)
-- Add time, location, details, maybe other properties to setlist to hold event details (ticket created)
+- Add time, location, details, maybe other properties to setlist to hold event details ✅ **COMPLETED**
 - User profile section. (ticket created)
 - Allow linking spotify after signing up with google. (ticket created)
 - Refactor to avoid code duplication.

--- a/app/bands/[id]/setlist/[setId]/page.tsx
+++ b/app/bands/[id]/setlist/[setId]/page.tsx
@@ -8,6 +8,7 @@ import ExportPDFButton from '@/components/ExportPDFButton';
 import getUser from "@/utils/getUser";
 import AddSongToSetDropdown from "@/components/AddSongToSetDropdown";
 import EditableField from "@/components/EditableField";
+import SetlistEventDetails from '@/components/SetlistEventDetails';
 
 
 const SetlistPage = async (context: any) => {
@@ -123,63 +124,14 @@ const SetlistPage = async (context: any) => {
             </div>
 
             {/* Event Details Section */}
-            <div className="mb-8 bg-white shadow rounded-lg p-6 border border-gray-200">
-                <div className="mb-4">
-                    <h3 className="text-lg font-semibold text-gray-900">Event Details</h3>
-                </div>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                        <span className="font-medium text-gray-700">Start Time:</span>{' '}
-                        <EditableField
-                            field="time"
-                            value={setList.time ? new Date(setList.time).toISOString().slice(0, 16) : ''}
-                            setListId={setList.id}
-                            type="datetime-local"
-                            placeholder="Set start time"
-                        />
-                    </div>
-                    <div>
-                        <span className="font-medium text-gray-700">End Time:</span>{' '}
-                        <EditableField
-                            field="endTime"
-                            value={setList.endTime ? new Date(setList.endTime).toISOString().slice(0, 16) : ''}
-                            setListId={setList.id}
-                            type="datetime-local"
-                            placeholder="Set end time"
-                        />
-                    </div>
-                    <div>
-                        <span className="font-medium text-gray-700">Location:</span>{' '}
-                        <EditableField
-                            field="location"
-                            value={setList.location || ''}
-                            setListId={setList.id}
-                            type="text"
-                            placeholder="Enter location"
-                        />
-                    </div>
-                    <div>
-                        <span className="font-medium text-gray-700">Details:</span>{' '}
-                        <EditableField
-                            field="details"
-                            value={setList.details || ''}
-                            setListId={setList.id}
-                            type="textarea"
-                            placeholder="Enter details"
-                        />
-                    </div>
-                    <div className="md:col-span-2">
-                        <span className="font-medium text-gray-700">Personnel:</span>{' '}
-                        <EditableField
-                            field="personel"
-                            value={setList.personel ? (typeof setList.personel === 'string' ? setList.personel : JSON.stringify(setList.personel, null, 2)) : ''}
-                            setListId={setList.id}
-                            type="textarea"
-                            placeholder="Enter personnel (JSON or array)"
-                        />
-                    </div>
-                </div>
-            </div>
+            <SetlistEventDetails
+                setListId={setList.id}
+                initialTime={setList.time}
+                initialEndTime={setList.endTime}
+                initialLocation={setList.location}
+                initialDetails={setList.details}
+                initialPersonel={setList.personel}
+            />
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
                 <div className="bg-white shadow rounded-lg order-2 lg:order-1">

--- a/app/bands/[id]/setlist/[setId]/page.tsx
+++ b/app/bands/[id]/setlist/[setId]/page.tsx
@@ -121,6 +121,39 @@ const SetlistPage = async (context: any) => {
                 </div>
             </div>
 
+            {/* Event Details Section */}
+            <div className="mb-8 bg-white shadow rounded-lg p-6 border border-gray-200">
+                <h3 className="text-lg font-semibold text-gray-900 mb-4">Event Details</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <span className="font-medium text-gray-700">Start Time:</span>{' '}
+                        {setList.time ? new Date(setList.time).toLocaleString() : <span className="text-gray-400">—</span>}
+                    </div>
+                    <div>
+                        <span className="font-medium text-gray-700">End Time:</span>{' '}
+                        {setList.endTime ? new Date(setList.endTime).toLocaleString() : <span className="text-gray-400">—</span>}
+                    </div>
+                    <div>
+                        <span className="font-medium text-gray-700">Location:</span>{' '}
+                        {setList.location || <span className="text-gray-400">—</span>}
+                    </div>
+                    <div>
+                        <span className="font-medium text-gray-700">Details:</span>{' '}
+                        {setList.details || <span className="text-gray-400">—</span>}
+                    </div>
+                    <div className="md:col-span-2">
+                        <span className="font-medium text-gray-700">Personnel:</span>{' '}
+                        {Array.isArray(setList.personel) ? (
+                            <ul className="list-disc ml-6 mt-1">
+                                {setList.personel.map((p: any, i: number) => <li key={i}>{p}</li>)}
+                            </ul>
+                        ) : setList.personel ? (
+                            <pre className="bg-gray-100 rounded p-2 mt-1 text-xs text-gray-700">{JSON.stringify(setList.personel, null, 2)}</pre>
+                        ) : <span className="text-gray-400">—</span>}
+                    </div>
+                </div>
+            </div>
+
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
                 <div className="bg-white shadow rounded-lg order-2 lg:order-1">
                     <div className="px-4 py-5 sm:px-6">

--- a/app/bands/[id]/setlist/[setId]/page.tsx
+++ b/app/bands/[id]/setlist/[setId]/page.tsx
@@ -7,6 +7,7 @@ import CreateSpotifyPlaylistModalButton from '@/components/CreateSpotifyPlaylist
 import ExportPDFButton from '@/components/ExportPDFButton';
 import getUser from "@/utils/getUser";
 import AddSongToSetDropdown from "@/components/AddSongToSetDropdown";
+import EditableField from "@/components/EditableField";
 
 
 const SetlistPage = async (context: any) => {
@@ -123,33 +124,59 @@ const SetlistPage = async (context: any) => {
 
             {/* Event Details Section */}
             <div className="mb-8 bg-white shadow rounded-lg p-6 border border-gray-200">
-                <h3 className="text-lg font-semibold text-gray-900 mb-4">Event Details</h3>
+                <div className="mb-4">
+                    <h3 className="text-lg font-semibold text-gray-900">Event Details</h3>
+                </div>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <span className="font-medium text-gray-700">Start Time:</span>{' '}
-                        {setList.time ? new Date(setList.time).toLocaleString() : <span className="text-gray-400">—</span>}
+                        <EditableField
+                            field="time"
+                            value={setList.time ? new Date(setList.time).toISOString().slice(0, 16) : ''}
+                            setListId={setList.id}
+                            type="datetime-local"
+                            placeholder="Set start time"
+                        />
                     </div>
                     <div>
                         <span className="font-medium text-gray-700">End Time:</span>{' '}
-                        {setList.endTime ? new Date(setList.endTime).toLocaleString() : <span className="text-gray-400">—</span>}
+                        <EditableField
+                            field="endTime"
+                            value={setList.endTime ? new Date(setList.endTime).toISOString().slice(0, 16) : ''}
+                            setListId={setList.id}
+                            type="datetime-local"
+                            placeholder="Set end time"
+                        />
                     </div>
                     <div>
                         <span className="font-medium text-gray-700">Location:</span>{' '}
-                        {setList.location || <span className="text-gray-400">—</span>}
+                        <EditableField
+                            field="location"
+                            value={setList.location || ''}
+                            setListId={setList.id}
+                            type="text"
+                            placeholder="Enter location"
+                        />
                     </div>
                     <div>
                         <span className="font-medium text-gray-700">Details:</span>{' '}
-                        {setList.details || <span className="text-gray-400">—</span>}
+                        <EditableField
+                            field="details"
+                            value={setList.details || ''}
+                            setListId={setList.id}
+                            type="textarea"
+                            placeholder="Enter details"
+                        />
                     </div>
                     <div className="md:col-span-2">
                         <span className="font-medium text-gray-700">Personnel:</span>{' '}
-                        {Array.isArray(setList.personel) ? (
-                            <ul className="list-disc ml-6 mt-1">
-                                {setList.personel.map((p: any, i: number) => <li key={i}>{p}</li>)}
-                            </ul>
-                        ) : setList.personel ? (
-                            <pre className="bg-gray-100 rounded p-2 mt-1 text-xs text-gray-700">{JSON.stringify(setList.personel, null, 2)}</pre>
-                        ) : <span className="text-gray-400">—</span>}
+                        <EditableField
+                            field="personel"
+                            value={setList.personel ? (typeof setList.personel === 'string' ? setList.personel : JSON.stringify(setList.personel, null, 2)) : ''}
+                            setListId={setList.id}
+                            type="textarea"
+                            placeholder="Enter personnel (JSON or array)"
+                        />
                     </div>
                 </div>
             </div>

--- a/app/bands/[id]/setlist/[setId]/page.tsx
+++ b/app/bands/[id]/setlist/[setId]/page.tsx
@@ -90,6 +90,15 @@ const SetlistPage = async (context: any) => {
         return editSetList(setIdOverride ?? setId, song, add)
     }
 
+    const bandMembers = await prisma.user.findMany({
+        where: {
+            bands: {
+                some: { id: Number(bandId) }
+            }
+        },
+        select: { id: true, name: true, email: true }
+    });
+
     return (
         <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
             <div className="md:flex md:items-center md:justify-between mb-8">
@@ -131,6 +140,7 @@ const SetlistPage = async (context: any) => {
                 initialLocation={setList.location}
                 initialDetails={setList.details}
                 initialPersonel={setList.personel}
+                bandMembers={bandMembers}
             />
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">

--- a/app/bands/[id]/setlist/[setId]/page.tsx
+++ b/app/bands/[id]/setlist/[setId]/page.tsx
@@ -135,12 +135,12 @@ const SetlistPage = async (context: any) => {
             {/* Event Details Section */}
             <SetlistEventDetails
                 setListId={setList.id}
-                initialTime={setList.time}
-                initialEndTime={setList.endTime}
+                initialTime={setList.time ? setList.time.toISOString() : null}
+                initialEndTime={setList.endTime ? setList.endTime.toISOString() : null}
                 initialLocation={setList.location}
                 initialDetails={setList.details}
                 initialPersonel={setList.personel}
-                bandMembers={bandMembers}
+                bandMembers={bandMembers.map(m => ({ ...m, id: Number(m.id) }))}
             />
 
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">

--- a/components/AddSetListForm.tsx
+++ b/components/AddSetListForm.tsx
@@ -39,9 +39,8 @@ const AddSetListForm = ({bandId, songs}: AddSetListFormProps) => {
     };
 
     const handleSubmit = (formData: FormData) => {
-        // Add personnel emails as JSON string
         formData.set('personel', JSON.stringify(personelList));
-        // Randomly select songs for each set, no duplicates across sets
+        // Restore original sets logic
         let available = [...songs];
         const sets = songsPerSet.map((num, idx) => {
             const selected = sampleSize(available, num);
@@ -148,6 +147,15 @@ const AddSetListForm = ({bandId, songs}: AddSetListFormProps) => {
                                                     type="datetime-local"
                                                     name="time"
                                                     id="time"
+                                                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                                />
+                                            </div>
+                                            <div>
+                                                <label htmlFor="endTime" className="block text-sm font-medium text-gray-700">End Time</label>
+                                                <input
+                                                    type="datetime-local"
+                                                    name="endTime"
+                                                    id="endTime"
                                                     className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                                                 />
                                             </div>

--- a/components/AddSetListForm.tsx
+++ b/components/AddSetListForm.tsx
@@ -16,6 +16,9 @@ const AddSetListForm = ({bandId, songs}: AddSetListFormProps) => {
     const formRef = useRef<HTMLFormElement>(null)
     const [numSets, setNumSets] = useState(1);
     const [songsPerSet, setSongsPerSet] = useState([1]);
+    // New state for personnel emails
+    const [personelEmail, setPersonelEmail] = useState("");
+    const [personelList, setPersonelList] = useState<string[]>([]);
 
     // Update songsPerSet array when numSets changes
     const handleNumSetsChange = (n: number) => {
@@ -36,6 +39,8 @@ const AddSetListForm = ({bandId, songs}: AddSetListFormProps) => {
     };
 
     const handleSubmit = (formData: FormData) => {
+        // Add personnel emails as JSON string
+        formData.set('personel', JSON.stringify(personelList));
         // Randomly select songs for each set, no duplicates across sets
         let available = [...songs];
         const sets = songsPerSet.map((num, idx) => {
@@ -133,6 +138,85 @@ const AddSetListForm = ({bandId, songs}: AddSetListFormProps) => {
                                             />
                                         </div>
                                     ))}
+                                    {/* Event Details Section */}
+                                    <div className="mt-8 pt-6 border-t border-gray-200">
+                                        <h4 className="text-md font-semibold text-gray-700 mb-4">Event Details</h4>
+                                        <div className="space-y-4">
+                                            <div>
+                                                <label htmlFor="time" className="block text-sm font-medium text-gray-700">Time</label>
+                                                <input
+                                                    type="datetime-local"
+                                                    name="time"
+                                                    id="time"
+                                                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                                />
+                                            </div>
+                                            <div>
+                                                <label htmlFor="location" className="block text-sm font-medium text-gray-700">Location</label>
+                                                <input
+                                                    type="text"
+                                                    name="location"
+                                                    id="location"
+                                                    placeholder="Venue, city, etc."
+                                                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                                />
+                                            </div>
+                                            <div>
+                                                <label htmlFor="details" className="block text-sm font-medium text-gray-700">Details</label>
+                                                <textarea
+                                                    name="details"
+                                                    id="details"
+                                                    placeholder="Any extra details about this set list..."
+                                                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                                    rows={3}
+                                                />
+                                            </div>
+                                            {/* Personnel email input */}
+                                            <div>
+                                                <label className="block text-sm font-medium text-gray-700">Band Member Emails</label>
+                                                <div className="flex gap-2 mt-1">
+                                                    <input
+                                                        type="email"
+                                                        value={personelEmail}
+                                                        onChange={e => setPersonelEmail(e.target.value)}
+                                                        placeholder="Enter email and press Add"
+                                                        className="block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                                                    />
+                                                    <button
+                                                        type="button"
+                                                        onClick={() => {
+                                                            if (personelEmail && !personelList.includes(personelEmail)) {
+                                                                setPersonelList([...personelList, personelEmail]);
+                                                                setPersonelEmail("");
+                                                            }
+                                                        }}
+                                                        className="inline-flex items-center px-3 py-1.5 border border-indigo-600 text-sm font-medium rounded-md text-indigo-700 bg-white hover:bg-indigo-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                                                    >
+                                                        Add
+                                                    </button>
+                                                </div>
+                                                {/* List of added emails */}
+                                                {personelList.length > 0 && (
+                                                    <ul className="mt-2 space-y-1">
+                                                        {personelList.map((email, idx) => (
+                                                            <li key={idx} className="flex items-center justify-between bg-gray-100 rounded px-2 py-1 text-sm">
+                                                                <span>{email}</span>
+                                                                <button
+                                                                    type="button"
+                                                                    onClick={() => setPersonelList(personelList.filter(e => e !== email))}
+                                                                    className="ml-2 text-red-500 hover:text-red-700 text-xs"
+                                                                >
+                                                                    Remove
+                                                                </button>
+                                                            </li>
+                                                        ))}
+                                                    </ul>
+                                                )}
+                                                {/* Hidden input for form submission */}
+                                                <input type="hidden" name="personel" value={JSON.stringify(personelList)} />
+                                            </div>
+                                        </div>
+                                    </div>
                                     <div className="mt-5 sm:mt-4 sm:flex sm:flex-row-reverse">
                                         <button
                                             type="submit"

--- a/components/EditableField.tsx
+++ b/components/EditableField.tsx
@@ -12,6 +12,27 @@ interface EditableFieldProps {
     onSave?: (newValue: string) => void;
 }
 
+function formatDateTime(dateString: string) {
+    if (!dateString) return '';
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) return dateString;
+    const month = date.toLocaleString('en-US', { month: 'short' });
+    const day = date.getDate();
+    const year = date.getFullYear();
+    const hours = date.getHours();
+    const minutes = date.getMinutes();
+    const ampm = hours >= 12 ? 'PM' : 'AM';
+    const hour12 = hours % 12 === 0 ? 12 : hours % 12;
+    const minuteStr = minutes.toString().padStart(2, '0');
+    // Ordinal suffix
+    const j = day % 10, k = day % 100;
+    let dayStr = day + 'th';
+    if (j === 1 && k !== 11) dayStr = day + 'st';
+    else if (j === 2 && k !== 12) dayStr = day + 'nd';
+    else if (j === 3 && k !== 13) dayStr = day + 'rd';
+    return `${month}. ${dayStr}, ${year} - ${hour12}:${minuteStr}${ampm}`;
+}
+
 const EditableField = ({ field, value, setListId, type, placeholder, onSave }: EditableFieldProps) => {
     const [isEditing, setIsEditing] = useState(false);
     const [editValue, setEditValue] = useState(value);
@@ -101,7 +122,10 @@ const EditableField = ({ field, value, setListId, type, placeholder, onSave }: E
         );
     }
 
-    const displayValue = value || <span className="text-gray-400 italic">Click to add</span>;
+    const displayValue =
+        type === 'datetime-local' && value
+            ? <span>{formatDateTime(value)}</span>
+            : value || <span className="text-gray-400 italic">Click to add</span>;
 
     return (
         <div className="group inline-flex items-center gap-1">

--- a/components/EditableField.tsx
+++ b/components/EditableField.tsx
@@ -7,11 +7,12 @@ interface EditableFieldProps {
     field: string;
     value: string;
     setListId: number;
-    type: 'text' | 'tarea' | 'datetime-local';
+    type: 'text' | 'textarea' | 'datetime-local';
     placeholder?: string;
+    onSave?: (newValue: string) => void;
 }
 
-const EditableField = ({ field, value, setListId, type, placeholder }: EditableFieldProps) => {
+const EditableField = ({ field, value, setListId, type, placeholder, onSave }: EditableFieldProps) => {
     const [isEditing, setIsEditing] = useState(false);
     const [editValue, setEditValue] = useState(value);
     const [isLoading, setIsLoading] = useState(false);
@@ -37,6 +38,7 @@ const EditableField = ({ field, value, setListId, type, placeholder }: EditableF
         try {
             await updateSetListField(setListId, field, editValue);
             setIsEditing(false);
+            if (onSave) onSave(editValue);
         } catch (error) {
             console.error('Failed to update field:', error);
             setEditValue(value); // Reset to original value on error

--- a/components/EditableField.tsx
+++ b/components/EditableField.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+import { updateSetListField } from '@/utils/serverActions';
+
+interface EditableFieldProps {
+    field: string;
+    value: string;
+    setListId: number;
+    type: 'text' | 'tarea' | 'datetime-local';
+    placeholder?: string;
+}
+
+const EditableField = ({ field, value, setListId, type, placeholder }: EditableFieldProps) => {
+    const [isEditing, setIsEditing] = useState(false);
+    const [editValue, setEditValue] = useState(value);
+    const [isLoading, setIsLoading] = useState(false);
+    const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+        setEditValue(value);
+    }, [value]);
+
+    useEffect(() => {
+        if (isEditing && inputRef.current) {
+            inputRef.current.focus();
+        }
+    }, [isEditing]);
+
+    const handleSave = async () => {
+        if (editValue === value) {
+            setIsEditing(false);
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            await updateSetListField(setListId, field, editValue);
+            setIsEditing(false);
+        } catch (error) {
+            console.error('Failed to update field:', error);
+            setEditValue(value); // Reset to original value on error
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleCancel = () => {
+        setEditValue(value);
+        setIsEditing(false);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' && type !== 'textarea') {
+            e.preventDefault();
+            handleSave();
+        } else if (e.key === 'Escape') {
+            handleCancel();
+        }
+    };
+
+    if (isEditing) {
+        return (
+            <div className="inline-block relative">
+                {type === 'textarea' ? (
+                    <textarea
+                        ref={inputRef as React.RefObject<HTMLTextAreaElement>}
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        onBlur={handleSave}
+                        placeholder={placeholder}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                        rows={2}
+                    />
+                ) : (
+                    <input
+                        ref={inputRef as React.RefObject<HTMLInputElement>}
+                        type={type}
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onKeyDown={handleKeyDown}
+                        onBlur={handleSave}
+                        placeholder={placeholder}
+                        className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                        disabled={isLoading}
+                    />
+                )}
+                {isLoading && (
+                    <div className="mt-1 text-xs text-gray-500 flex items-center">
+                        <svg className="animate-spin -ml-1 mr-2 h-4 w-4 text-indigo-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3.584-3.584"></path>
+                        </svg>
+                        Saving...
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    const displayValue = value || <span className="text-gray-400 italic">Click to add</span>;
+
+    return (
+        <div className="group inline-flex items-center gap-1">
+            <span
+                onClick={() => setIsEditing(true)}
+                className="cursor-pointer hover:bg-indigo-50 hover:text-indigo-700 rounded-md transition-all duration-200 border-transparent hover:border-indigo-200 group-hover:border-indigo-300"
+                title="Click to edit"
+            >
+                {displayValue}
+            </span>
+            <span 
+                className="h-4 w-4 text-gray-400 opacity-0 group-hover:opacity-100 transition-opacity duration-200"
+                title="Edit"
+            >
+                ✏️
+            </span>
+        </div>
+    );
+};
+
+export default EditableField; 

--- a/components/EditablePersonelList.tsx
+++ b/components/EditablePersonelList.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useState } from 'react';
+
+interface BandMember {
+  id: number;
+  name: string | null;
+  email: string | null;
+}
+
+interface EditablePersonelListProps {
+  value: string[];
+  onChange: (newList: string[]) => void;
+  setListId: number;
+  bandMembers: BandMember[];
+}
+
+function isValidEmail(email: string) {
+  return /^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email);
+}
+
+const EditablePersonelList = ({ value, onChange, setListId, bandMembers }: EditablePersonelListProps) => {
+  const [input, setInput] = useState('');
+  const [suggestions, setSuggestions] = useState<BandMember[]>([]);
+  const [error, setError] = useState('');
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value;
+    setInput(val);
+    setError('');
+    if (val.length > 0) {
+      setSuggestions(
+        bandMembers.filter(
+          m => m.email && m.email.toLowerCase().includes(val.toLowerCase())
+        )
+      );
+    } else {
+      setSuggestions([]);
+    }
+  };
+
+  const handleAdd = (person: string) => {
+    if (!person.trim() || value.includes(person.trim())) return;
+    if (!isValidEmail(person.trim())) {
+      setError('Please enter a valid email address.');
+      return;
+    }
+    const newList = [...value, person.trim()];
+    onChange(newList);
+    setInput('');
+    setSuggestions([]);
+    setError('');
+  };
+
+  const handleRemove = (person: string) => {
+    const newList = value.filter(p => p !== person);
+    onChange(newList);
+  };
+
+  return (
+    <div>
+      <ul className="mb-2">
+        {value.map((person, idx) => (
+          <li key={idx} className="inline-flex items-center bg-gray-100 rounded px-2 py-1 mr-2 mb-2">
+            <span>{person}</span>
+            <button
+              type="button"
+              className="ml-2 text-red-500 hover:text-red-700"
+              onClick={() => handleRemove(person)}
+              aria-label="Remove"
+            >
+              &times;
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="relative">
+        <input
+          type="text"
+          value={input}
+          onChange={handleInputChange}
+          placeholder="Add person (email)"
+          className="border rounded px-2 py-1 w-full"
+          onKeyDown={e => {
+            if (e.key === 'Enter') {
+              handleAdd(input);
+            }
+          }}
+        />
+        {error && <div className="text-xs text-red-500 mt-1">{error}</div>}
+        {suggestions.length > 0 && (
+          <ul className="absolute z-10 bg-white border rounded w-full mt-1 max-h-40 overflow-y-auto shadow">
+            {suggestions.map((m, i) => (
+              <li
+                key={m.id + '-' + i}
+                className="px-2 py-1 hover:bg-indigo-100 cursor-pointer"
+                onClick={() => handleAdd(m.email || '')}
+              >
+                {m.name} {m.email && <span className="text-xs text-gray-500">({m.email})</span>}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default EditablePersonelList; 

--- a/components/SetlistEventDetails.tsx
+++ b/components/SetlistEventDetails.tsx
@@ -35,80 +35,98 @@ const SetlistEventDetails = ({
       ? (typeof initialPersonel === 'string' ? [initialPersonel] : [])
       : []
   );
+  const [open, setOpen] = useState(false);
 
   return (
-    <div className="mb-8 bg-white shadow rounded-lg p-6 border border-gray-200">
-      <div className="mb-4">
-        <h3 className="text-lg font-semibold text-gray-900">Event Details</h3>
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
-        <div className="flex items-center">
-          <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">Start Time:</span>
-          <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
-            <EditableField
-              field="time"
-              value={time ? new Date(time).toISOString().slice(0, 16) : ''}
-              setListId={setListId}
-              type="datetime-local"
-              placeholder="Set start time"
-              onSave={setTime}
-            />
-          </span>
+    <div className="mb-8 bg-white shadow rounded-lg border border-gray-200">
+      <button
+        className="w-full flex items-center justify-between px-6 py-4 text-lg font-semibold text-gray-900 focus:outline-none hover:bg-gray-50 rounded-t-lg transition-colors"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls="event-details-content"
+      >
+        <span>Event Details</span>
+        <svg
+          className={`h-5 w-5 transform transition-transform duration-200 ${open ? 'rotate-180' : ''}`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      {open && (
+        <div id="event-details-content" className="p-6 pt-0">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+            <div className="flex items-center">
+              <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">Start Time:</span>
+              <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
+                <EditableField
+                  field="time"
+                  value={time ? new Date(time).toISOString().slice(0, 16) : ''}
+                  setListId={setListId}
+                  type="datetime-local"
+                  placeholder="Set start time"
+                  onSave={setTime}
+                />
+              </span>
+            </div>
+            <div className="flex items-center">
+              <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">End Time:</span>
+              <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
+                <EditableField
+                  field="endTime"
+                  value={endTime ? new Date(endTime).toISOString().slice(0, 16) : ''}
+                  setListId={setListId}
+                  type="datetime-local"
+                  placeholder="Set end time"
+                  onSave={setEndTime}
+                />
+              </span>
+            </div>
+            <div className="flex items-center">
+              <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">Location:</span>
+              <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
+                <EditableField
+                  field="location"
+                  value={location || ''}
+                  setListId={setListId}
+                  type="text"
+                  placeholder="Enter location"
+                  onSave={setLocation}
+                />
+              </span>
+            </div>
+            <div className="flex items-center">
+              <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">Details:</span>
+              <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
+                <EditableField
+                  field="details"
+                  value={details || ''}
+                  setListId={setListId}
+                  type="textarea"
+                  placeholder="Enter details"
+                  onSave={setDetails}
+                />
+              </span>
+            </div>
+            <div className="md:col-span-2 flex items-start">
+              <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4 pt-2">Band Members:</span>
+              <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
+                <EditablePersonelList
+                  value={personel}
+                  setListId={setListId}
+                  bandMembers={bandMembers}
+                  onChange={async (newList) => {
+                    setPersonel(newList);
+                    await updateSetListField(setListId, 'personel', JSON.stringify(newList));
+                  }}
+                />
+              </span>
+            </div>
+          </div>
         </div>
-        <div className="flex items-center">
-          <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">End Time:</span>
-          <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
-            <EditableField
-              field="endTime"
-              value={endTime ? new Date(endTime).toISOString().slice(0, 16) : ''}
-              setListId={setListId}
-              type="datetime-local"
-              placeholder="Set end time"
-              onSave={setEndTime}
-            />
-          </span>
-        </div>
-        <div className="flex items-center">
-          <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">Location:</span>
-          <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
-            <EditableField
-              field="location"
-              value={location || ''}
-              setListId={setListId}
-              type="text"
-              placeholder="Enter location"
-              onSave={setLocation}
-            />
-          </span>
-        </div>
-        <div className="flex items-center">
-          <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">Details:</span>
-          <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
-            <EditableField
-              field="details"
-              value={details || ''}
-              setListId={setListId}
-              type="textarea"
-              placeholder="Enter details"
-              onSave={setDetails}
-            />
-          </span>
-        </div>
-        <div className="md:col-span-2 flex items-start">
-          <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4 pt-2">Band Members:</span>
-          <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
-            <EditablePersonelList
-              value={personel}
-              setListId={setListId}
-              bandMembers={bandMembers}
-              onChange={async (newList) => {
-                setPersonel(newList);
-                await updateSetListField(setListId, 'personel', JSON.stringify(newList));
-              }}
-            />
-          </span>
-        </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/components/SetlistEventDetails.tsx
+++ b/components/SetlistEventDetails.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import EditableField from './EditableField';
+
+interface SetlistEventDetailsProps {
+  setListId: number;
+  initialTime: string | null;
+  initialEndTime: string | null;
+  initialLocation: string | null;
+  initialDetails: string | null;
+  initialPersonel: any;
+}
+
+const SetlistEventDetails = ({
+  setListId,
+  initialTime,
+  initialEndTime,
+  initialLocation,
+  initialDetails,
+  initialPersonel,
+}: SetlistEventDetailsProps) => {
+  const [time, setTime] = useState(initialTime);
+  const [endTime, setEndTime] = useState(initialEndTime);
+  const [location, setLocation] = useState(initialLocation);
+  const [details, setDetails] = useState(initialDetails);
+  const [personel, setPersonel] = useState(
+    initialPersonel ? (typeof initialPersonel === 'string' ? initialPersonel : JSON.stringify(initialPersonel, null, 2)) : ''
+  );
+
+  return (
+    <div className="mb-8 bg-white shadow rounded-lg p-6 border border-gray-200">
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold text-gray-900">Event Details</h3>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div>
+          <span className="font-medium text-gray-700">Start Time:</span>{' '}
+          <EditableField
+            field="time"
+            value={time ? new Date(time).toISOString().slice(0, 16) : ''}
+            setListId={setListId}
+            type="datetime-local"
+            placeholder="Set start time"
+            onSave={setTime}
+          />
+        </div>
+        <div>
+          <span className="font-medium text-gray-700">End Time:</span>{' '}
+          <EditableField
+            field="endTime"
+            value={endTime ? new Date(endTime).toISOString().slice(0, 16) : ''}
+            setListId={setListId}
+            type="datetime-local"
+            placeholder="Set end time"
+            onSave={setEndTime}
+          />
+        </div>
+        <div>
+          <span className="font-medium text-gray-700">Location:</span>{' '}
+          <EditableField
+            field="location"
+            value={location || ''}
+            setListId={setListId}
+            type="text"
+            placeholder="Enter location"
+            onSave={setLocation}
+          />
+        </div>
+        <div>
+          <span className="font-medium text-gray-700">Details:</span>{' '}
+          <EditableField
+            field="details"
+            value={details || ''}
+            setListId={setListId}
+            type="textarea"
+            placeholder="Enter details"
+            onSave={setDetails}
+          />
+        </div>
+        <div className="md:col-span-2">
+          <span className="font-medium text-gray-700">Personnel:</span>{' '}
+          <EditableField
+            field="personel"
+            value={personel}
+            setListId={setListId}
+            type="textarea"
+            placeholder="Enter personnel (JSON or array)"
+            onSave={setPersonel}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SetlistEventDetails; 

--- a/components/SetlistEventDetails.tsx
+++ b/components/SetlistEventDetails.tsx
@@ -41,62 +41,72 @@ const SetlistEventDetails = ({
       <div className="mb-4">
         <h3 className="text-lg font-semibold text-gray-900">Event Details</h3>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <span className="font-medium text-gray-700">Start Time:</span>{' '}
-          <EditableField
-            field="time"
-            value={time ? new Date(time).toISOString().slice(0, 16) : ''}
-            setListId={setListId}
-            type="datetime-local"
-            placeholder="Set start time"
-            onSave={setTime}
-          />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+        <div className="flex items-center">
+          <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">Start Time:</span>
+          <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
+            <EditableField
+              field="time"
+              value={time ? new Date(time).toISOString().slice(0, 16) : ''}
+              setListId={setListId}
+              type="datetime-local"
+              placeholder="Set start time"
+              onSave={setTime}
+            />
+          </span>
         </div>
-        <div>
-          <span className="font-medium text-gray-700">End Time:</span>{' '}
-          <EditableField
-            field="endTime"
-            value={endTime ? new Date(endTime).toISOString().slice(0, 16) : ''}
-            setListId={setListId}
-            type="datetime-local"
-            placeholder="Set end time"
-            onSave={setEndTime}
-          />
+        <div className="flex items-center">
+          <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">End Time:</span>
+          <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
+            <EditableField
+              field="endTime"
+              value={endTime ? new Date(endTime).toISOString().slice(0, 16) : ''}
+              setListId={setListId}
+              type="datetime-local"
+              placeholder="Set end time"
+              onSave={setEndTime}
+            />
+          </span>
         </div>
-        <div>
-          <span className="font-medium text-gray-700">Location:</span>{' '}
-          <EditableField
-            field="location"
-            value={location || ''}
-            setListId={setListId}
-            type="text"
-            placeholder="Enter location"
-            onSave={setLocation}
-          />
+        <div className="flex items-center">
+          <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">Location:</span>
+          <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
+            <EditableField
+              field="location"
+              value={location || ''}
+              setListId={setListId}
+              type="text"
+              placeholder="Enter location"
+              onSave={setLocation}
+            />
+          </span>
         </div>
-        <div>
-          <span className="font-medium text-gray-700">Details:</span>{' '}
-          <EditableField
-            field="details"
-            value={details || ''}
-            setListId={setListId}
-            type="textarea"
-            placeholder="Enter details"
-            onSave={setDetails}
-          />
+        <div className="flex items-center">
+          <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4">Details:</span>
+          <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
+            <EditableField
+              field="details"
+              value={details || ''}
+              setListId={setListId}
+              type="textarea"
+              placeholder="Enter details"
+              onSave={setDetails}
+            />
+          </span>
         </div>
-        <div className="md:col-span-2">
-          <span className="font-medium text-gray-700">Band Members:</span>{' '}
-          <EditablePersonelList
-            value={personel}
-            setListId={setListId}
-            bandMembers={bandMembers}
-            onChange={async (newList) => {
-              setPersonel(newList);
-              await updateSetListField(setListId, 'personel', JSON.stringify(newList));
-            }}
-          />
+        <div className="md:col-span-2 flex items-start">
+          <span className="w-32 md:w-40 font-semibold text-gray-800 text-right block mr-4 pt-2">Band Members:</span>
+          <span className="flex-1 bg-gray-50 rounded px-2 py-1 text-gray-900">
+            <EditablePersonelList
+              value={personel}
+              setListId={setListId}
+              bandMembers={bandMembers}
+              onChange={async (newList) => {
+                setPersonel(newList);
+                await updateSetListField(setListId, 'personel', JSON.stringify(newList));
+              }}
+            />
+          </span>
         </div>
       </div>
     </div>

--- a/components/SetlistEventDetails.tsx
+++ b/components/SetlistEventDetails.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 import EditableField from './EditableField';
+import EditablePersonelList from './EditablePersonelList';
+import { updateSetListField } from '@/utils/serverActions';
 
 interface SetlistEventDetailsProps {
   setListId: number;
@@ -10,6 +12,7 @@ interface SetlistEventDetailsProps {
   initialLocation: string | null;
   initialDetails: string | null;
   initialPersonel: any;
+  bandMembers: { id: number; name: string | null; email: string | null }[];
 }
 
 const SetlistEventDetails = ({
@@ -19,13 +22,18 @@ const SetlistEventDetails = ({
   initialLocation,
   initialDetails,
   initialPersonel,
+  bandMembers,
 }: SetlistEventDetailsProps) => {
   const [time, setTime] = useState(initialTime);
   const [endTime, setEndTime] = useState(initialEndTime);
   const [location, setLocation] = useState(initialLocation);
   const [details, setDetails] = useState(initialDetails);
   const [personel, setPersonel] = useState(
-    initialPersonel ? (typeof initialPersonel === 'string' ? initialPersonel : JSON.stringify(initialPersonel, null, 2)) : ''
+    Array.isArray(initialPersonel)
+      ? initialPersonel
+      : initialPersonel
+      ? (typeof initialPersonel === 'string' ? [initialPersonel] : [])
+      : []
   );
 
   return (
@@ -79,14 +87,15 @@ const SetlistEventDetails = ({
           />
         </div>
         <div className="md:col-span-2">
-          <span className="font-medium text-gray-700">Personnel:</span>{' '}
-          <EditableField
-            field="personel"
+          <span className="font-medium text-gray-700">Band Members:</span>{' '}
+          <EditablePersonelList
             value={personel}
             setListId={setListId}
-            type="textarea"
-            placeholder="Enter personnel (JSON or array)"
-            onSave={setPersonel}
+            bandMembers={bandMembers}
+            onChange={async (newList) => {
+              setPersonel(newList);
+              await updateSetListField(setListId, 'personel', JSON.stringify(newList));
+            }}
           />
         </div>
       </div>

--- a/prisma/migrations/20250716201231_add_time_location_details_personel_to_setlist/migration.sql
+++ b/prisma/migrations/20250716201231_add_time_location_details_personel_to_setlist/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "SetList" ADD COLUMN     "details" TEXT,
+ADD COLUMN     "location" VARCHAR(255),
+ADD COLUMN     "personel" JSONB,
+ADD COLUMN     "time" TIMESTAMP(3);

--- a/prisma/migrations/20250716203744_add_end_time_to_song/migration.sql
+++ b/prisma/migrations/20250716203744_add_end_time_to_song/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Song" ADD COLUMN     "endTime" TIMESTAMP(3);

--- a/prisma/migrations/20250716204326_move_end_time_to_setlist/migration.sql
+++ b/prisma/migrations/20250716204326_move_end_time_to_setlist/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `endTime` on the `Song` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "SetList" ADD COLUMN     "endTime" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "Song" DROP COLUMN "endTime";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,6 +50,11 @@ model SetList {
   band      Band     @relation(fields: [bandId], references: [id])
   bandId    Int
   sets      Set[]
+  // New optional fields
+  time      DateTime?
+  location  String?   @db.VarChar(255)
+  details   String?   @db.Text
+  personel  Json?
 }
 
 model User {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,6 +39,8 @@ model Song {
   setSongs  SetSong[]
   tags      Json?
   chart     String?
+  // New field
+  endTime   DateTime?
 }
 
 model SetList {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,8 +39,7 @@ model Song {
   setSongs  SetSong[]
   tags      Json?
   chart     String?
-  // New field
-  endTime   DateTime?
+  // Removed endTime from here
 }
 
 model SetList {
@@ -57,6 +56,7 @@ model SetList {
   location  String?   @db.VarChar(255)
   details   String?   @db.Text
   personel  Json?
+  endTime   DateTime?
 }
 
 model User {

--- a/utils/serverActions.ts
+++ b/utils/serverActions.ts
@@ -131,6 +131,21 @@ export const addSetList = async (
     data: {
       name: formData.get('name') as string,
       bandId: Number(bandId),
+      // New fields
+      time: formData.get('time') ? new Date(formData.get('time') as string) : undefined,
+      location: formData.get('location') as string || undefined,
+      details: formData.get('details') as string || undefined,
+      personel: (() => {
+        const val = formData.get('personel');
+        if (typeof val === 'string' && val.trim()) {
+          try {
+            return JSON.parse(val);
+          } catch {
+            return undefined;
+          }
+        }
+        return undefined;
+      })(),
     },
   });
 

--- a/utils/serverActions.ts
+++ b/utils/serverActions.ts
@@ -133,6 +133,7 @@ export const addSetList = async (
       bandId: Number(bandId),
       // New fields
       time: formData.get('time') ? new Date(formData.get('time') as string) : undefined,
+      endTime: formData.get('endTime') ? new Date(formData.get('endTime') as string) : undefined,
       location: formData.get('location') as string || undefined,
       details: formData.get('details') as string || undefined,
       personel: (() => {

--- a/utils/serverActions.ts
+++ b/utils/serverActions.ts
@@ -448,3 +448,76 @@ export const reorderSetListSongs = async (setId: number, orderedSetSongIds: numb
   );
   return revalidatePath(`/bands/set/${setId}`);
 };
+
+export async function updateSetListDetails(
+    setListId: number,
+    formData: FormData
+) {
+    const time = formData.get('time');
+    const endTime = formData.get('endTime');
+    const location = formData.get('location') as string;
+    const details = formData.get('details') as string;
+    const personel = (() => {
+        const val = formData.get('personel');
+        if (typeof val === 'string' && val.trim()) {
+            try {
+                return JSON.parse(val);
+            } catch {
+                return undefined;
+            }
+        }
+        return undefined;
+    })();
+
+    await prisma.setList.update({
+        where: { id: setListId },
+        data: {
+            time: time ? new Date(time as string) : null,
+            endTime: endTime ? new Date(endTime as string) : null,
+            location: location || null,
+            details: details || null,
+            personel,
+        },
+    });
+}
+
+export async function updateSetListField(
+    setListId: number,
+    field: string,
+    value: string
+) {
+    const updateData: any = {};
+    
+    switch (field) {
+        case 'time':
+            updateData.time = value ? new Date(value) : null;
+            break;
+        case 'endTime':
+            updateData.endTime = value ? new Date(value) : null;
+            break;
+        case 'location':
+            updateData.location = value || null;
+            break;
+        case 'details':
+            updateData.details = value || null;
+            break;
+        case 'personel':
+            if (value.trim()) {
+                try {
+                    updateData.personel = JSON.parse(value);
+                } catch {
+                    updateData.personel = undefined;
+                }
+            } else {
+                updateData.personel = null;
+            }
+            break;
+        default:
+            throw new Error(`Unknown field: ${field}`);
+    }
+
+    await prisma.setList.update({
+        where: { id: setListId },
+        data: updateData,
+    });
+}


### PR DESCRIPTION
This PR adds new fields to the Setlist model, to include more details (optionally) about the event the setlist is for. These new fields are added to the create setlist modal and there is a new Event Details section on a setlist page.
<img width="1236" height="326" alt="Screenshot 2025-07-17 at 1 45 00 PM" src="https://github.com/user-attachments/assets/c7d36cbf-a9a5-497a-beba-caa8d4c78cdd" />
<img width="1202" height="604" alt="Screenshot 2025-07-17 at 1 45 09 PM" src="https://github.com/user-attachments/assets/913ef7a1-c633-4c2d-bbdc-3abde453f82f" />
<img width="469" height="734" alt="Screenshot 2025-07-17 at 1 45 20 PM" src="https://github.com/user-attachments/assets/e65108a0-3acb-47d9-b9ed-5c827accee6d" />
